### PR TITLE
Add CI check for version consistency

### DIFF
--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Verifies the plugin's version is declared consistently across the three files
+# that must always agree, and (optionally) that it matches a release tag.
+#
+# Usage:
+#   check-versions.sh            # only checks the three files agree with each other
+#   check-versions.sh <tag>      # also checks they match the given release tag
+#
+set -euo pipefail
+
+header_version=$(grep -iE '^[[:space:]]*\*[[:space:]]*Version:' beautiful-taxonomy-filters.php \
+  | head -1 | sed -E 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
+readme_version=$(grep -iE '^Stable tag:' README.txt \
+  | head -1 | sed -E 's/.*Stable tag:[[:space:]]*//' | tr -d '[:space:]')
+class_version=$(grep -E '\$this->version[[:space:]]*=' includes/class-beautiful-taxonomy-filters.php \
+  | head -1 | sed -E "s/.*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/")
+
+echo "Plugin header (beautiful-taxonomy-filters.php) : ${header_version:-<empty>}"
+echo "README.txt (Stable tag)                        : ${readme_version:-<empty>}"
+echo "Class (\$this->version)                          : ${class_version:-<empty>}"
+
+fail=0
+
+for v in "$header_version" "$readme_version" "$class_version"; do
+  if [ -z "$v" ]; then
+    echo "::error::Could not extract one of the version strings."
+    fail=1
+  fi
+done
+
+if [ "$header_version" != "$readme_version" ] || [ "$header_version" != "$class_version" ]; then
+  echo "::error::Version strings are out of sync across the three files."
+  fail=1
+fi
+
+if [ "${1:-}" != "" ]; then
+  tag="$1"
+  echo "Release tag                                    : $tag"
+  if [ "$header_version" != "$tag" ]; then
+    echo "::error::Release tag ($tag) does not match the plugin version ($header_version)."
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "Version check FAILED."
+  exit 1
+fi
+
+echo "Version check passed."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verify version matches the release tag
+        run: bash .github/scripts/check-versions.sh "${{ github.event.release.tag_name }}"
+
       - name: WordPress Plugin Deploy
         id: deploy
         uses: 10up/action-wordpress-plugin-deploy@stable

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,23 @@
+name: Version consistency
+
+# Fails if the plugin version is not declared identically in all three places:
+#   - beautiful-taxonomy-filters.php  (Version: header)
+#   - README.txt                      (Stable tag:)
+#   - includes/class-beautiful-taxonomy-filters.php  ($this->version)
+# This catches the easy-to-miss drift before a release is cut.
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  versions:
+    name: Check version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check versions agree
+        run: bash .github/scripts/check-versions.sh


### PR DESCRIPTION
Guards against the version-drift problem (the `$this->version` constant historically fell out of sync with the plugin header / readme).

**What it adds**
- `.github/scripts/check-versions.sh` — extracts the version from the three sources and fails if they disagree; with a tag argument, also checks they match it.
- `.github/workflows/version-check.yml` — runs the check on PRs and pushes to `master` (internal consistency).
- `deploy.yml` — a step before the deploy asserts the three versions match the **release tag**, so a mismatched release can't be published to WordPress.org.

**Tested locally** against the current tree (2.4.9): passes on match, fails on a mismatched tag.